### PR TITLE
Adding w8s4 script.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN \
 RUN \
  cd /usr/local/bin; \
  wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh; \
- chmod +x /usr/local/bin/wait-for-it.sh
+ wget -q https://raw.githubusercontent.com/kbase-infra/w8s4/main/w8s4; \
+ chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/w8s4
 
 # Install minio mc admin utility
 RUN \


### PR DESCRIPTION
Adds the [w8s4](https://github.com/kbase-infra/w8s4) script to the init-sidecar image, allowing dependency checks between Rancrher2 services without a separate "init" repo. All host:port "wait for" commands will be loaded from a ConfigMap.