### PR TITLE
Pull new w8s4 script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # init-sidecar
+
 Docker config for the KBase `init-sidecar` and `install` services. For use with Rancher 2.
 
 ## Current Status


### PR DESCRIPTION
Forcing re-build of image to pull in latest [w8s4](https://github.com/kbase-infra/w8s4), with updated default ConfigMap mount path (now `/kb/init/w8s4`).